### PR TITLE
fix: specify topic type when executing ros2 topic echo

### DIFF
--- a/yaml/ros2-sample.yaml
+++ b/yaml/ros2-sample.yaml
@@ -118,7 +118,7 @@ spec:
       containers:
       - image: tomoyafujita/ros:rolling
         command: ["/bin/bash", "-c"]
-        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter1"]
+        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter1 std_msgs/String"]
         imagePullPolicy: IfNotPresent
         tty: true
         name: ros2-listener-1
@@ -152,7 +152,7 @@ spec:
       containers:
       - image: tomoyafujita/ros:rolling
         command: ["/bin/bash", "-c"]
-        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter2"]
+        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter2 std_msgs/String"]
         imagePullPolicy: IfNotPresent
         tty: true
         name: ros2-listener-2
@@ -186,7 +186,7 @@ spec:
       containers:
       - image: tomoyafujita/ros:rolling
         command: ["/bin/bash", "-c"]
-        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter3"]
+        args: ["source /opt/ros/$ROS_DISTRO/setup.bash && ros2 topic echo /chatter3 std_msgs/String"]
         imagePullPolicy: IfNotPresent
         tty: true
         name: ros2-listener-3


### PR DESCRIPTION
- specify topic type to avoid failing `ros2 topic echo` like
```
❯ ros2 topic echo /chatter1
WARNING: topic [/chatter1] does not appear to be published yet
Could not determine the type for the passed topic
```